### PR TITLE
Fix a bug that caused the 'account_is_iban' field to not be set.

### DIFF
--- a/src/DetailParsers/OriginalSituationParser.php
+++ b/src/DetailParsers/OriginalSituationParser.php
@@ -36,7 +36,12 @@ class OriginalSituationParser implements ParserInterface
 		return $coda1;
 	}
 
-	private function add_account_info(&$coda1, $account_info, $account_type)
+	/**
+	 * @param \Codelicious\Coda\Data\Raw\OriginalSituation $coda1
+	 * @param string $account_info
+	 * @param string $account_type
+	 */
+	private function add_account_info($coda1, $account_info, $account_type)
 	{
 		if ($account_type == "0") {
 			$coda1->account_number = substr($account_info, 0, 12);
@@ -48,13 +53,13 @@ class OriginalSituationParser implements ParserInterface
 			$coda1->account_currency = substr($account_info, 34, 3);
 		}
 		else if ($account_type == "2") {
-			$coda1->is_iban = TRUE;
+			$coda1->account_is_iban = TRUE;
 			$coda1->account_number = substr($account_info, 0, 31);
 			$coda1->account_currency = substr($account_info, 34, 3);
 			$coda1->account_country = "BE";
 		}
 		else if ($account_type == "3") {
-			$coda1->is_iban = TRUE;
+			$coda1->account_is_iban = TRUE;
 			$coda1->account_number = substr($account_info, 0, 34);
 			$coda1->account_currency = substr($account_info, 34, 3);
 		}

--- a/tests/DetailParsers/OriginalSituationParserTest.php
+++ b/tests/DetailParsers/OriginalSituationParserTest.php
@@ -26,4 +26,17 @@ class OriginalSituationParserTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals("PROFESSIONAL ACCOUNT", $result->account_description);
 		$this->assertEquals("255", $result->sequence_number);
 	}
+
+	public function testAccountIsIbanIsSetCorrectly ()
+	{
+		$parser = new \Codelicious\Coda\DetailParsers\OriginalSituationParser();
+
+		$sample = "13155001548226815 EUR0BE                  0000000004004100241214CODELICIOUS               PROFESSIONAL ACCOUNT               255";
+
+		$this->assertEquals(TRUE, $parser->accept_string($sample));
+
+		$result = $parser->parse($sample);
+
+		$this->assertEquals(TRUE, $result->account_is_iban);
+	}
 }


### PR DESCRIPTION
Instead of `account_is_iban`, `is_iban` was being set, which is not correct.

This does however techincally break backwards compatibility, but it's up to you whether or not this should become version 2.0.0.