### PR TITLE
Show coda sequences

### DIFF
--- a/src/LineParsers/IdentificationLineParser.php
+++ b/src/LineParsers/IdentificationLineParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\formatDateString;
-use function Codelicious\Coda\Helpers\getTrimmedData;
 use Codelicious\Coda\Lines\IdentificationLine;
 use Codelicious\Coda\Values\AccountName;
 use Codelicious\Coda\Values\ApplicationCode;
@@ -45,7 +43,7 @@ class IdentificationLineParser implements LineParserInterface
 			new VersionCode(mb_substr($codaLine, 127, 1))
 		);
 	}
-	
+
 	/**
 	 * Check if the parser take into account this type of line
 	 *

--- a/src/LineParsers/InformationPart1LineParser.php
+++ b/src/LineParsers/InformationPart1LineParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\getTrimmedData;
-use function Codelicious\Coda\Helpers\trimSpace;
 use Codelicious\Coda\Lines\InformationPart1Line;
 use Codelicious\Coda\Values\BankReference;
 use Codelicious\Coda\Values\MessageOrStructuredMessage;
@@ -25,7 +23,7 @@ class InformationPart1LineParser implements LineParserInterface
 	public function parse(string $codaLine)
 	{
 		$transactionCode = new TransactionCode(mb_substr($codaLine, 31, 8));
-		
+
 		return new InformationPart1Line(
 			new SequenceNumber(mb_substr($codaLine, 2, 4)),
 			new SequenceNumberDetail(mb_substr($codaLine, 6, 4)),
@@ -35,7 +33,7 @@ class InformationPart1LineParser implements LineParserInterface
 		);
 	}
 
-	
+
 	public function canAcceptString(string $codaLine)
 	{
 		return mb_strlen($codaLine) == 128 && mb_substr($codaLine, 0, 2) == "31";

--- a/src/LineParsers/InformationPart2LineParser.php
+++ b/src/LineParsers/InformationPart2LineParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\getTrimmedData;
-use function Codelicious\Coda\Helpers\trimSpace;
 use Codelicious\Coda\Lines\InformationPart2Line;
 use Codelicious\Coda\Values\Message;
 use Codelicious\Coda\Values\SequenceNumber;
@@ -28,7 +26,7 @@ class InformationPart2LineParser implements LineParserInterface
 			new Message(mb_substr($codaLine, 10, 105))
 		);
 	}
-	
+
 	public function canAcceptString(string $codaLine)
 	{
 		return mb_strlen($codaLine) == 128 && mb_substr($codaLine, 0, 2) == "32";

--- a/src/LineParsers/InformationPart3LineParser.php
+++ b/src/LineParsers/InformationPart3LineParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\getTrimmedData;
-use function Codelicious\Coda\Helpers\trimSpace;
 use Codelicious\Coda\Lines\InformationPart3Line;
 use Codelicious\Coda\Values\Message;
 use Codelicious\Coda\Values\SequenceNumber;
@@ -28,7 +26,7 @@ class InformationPart3LineParser implements LineParserInterface
 			new Message(mb_substr($codaLine, 10, 90))
 		);
 	}
-	
+
 	public function canAcceptString(string $codaLine)
 	{
 		return mb_strlen($codaLine) == 128 && mb_substr($codaLine, 0, 2) == "33";

--- a/src/LineParsers/MessageLineParser.php
+++ b/src/LineParsers/MessageLineParser.php
@@ -2,7 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\getTrimmedData;
 use Codelicious\Coda\Lines\MessageLine;
 use Codelicious\Coda\Values\Message;
 use Codelicious\Coda\Values\SequenceNumber;
@@ -27,7 +26,7 @@ class MessageLineParser implements LineParserInterface
 			new Message(mb_substr($codaLine, 32, 80))
 		);
 	}
-	
+
 	public function canAcceptString(string $codaLine)
 	{
 		return mb_strlen($codaLine) == 128 && mb_substr($codaLine, 0, 1) == "4";

--- a/src/LineParsers/NewStateLineParser.php
+++ b/src/LineParsers/NewStateLineParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\formatDateString;
-use function Codelicious\Coda\Helpers\getTrimmedData;
 use Codelicious\Coda\Lines\NewStateLine;
 use Codelicious\Coda\Values\AccountFull;
 use Codelicious\Coda\Values\Amount;
@@ -30,7 +28,7 @@ class NewStateLineParser implements LineParserInterface
 			new Date(mb_substr($codaLine, 57, 6))
 		);
 	}
-	
+
 	public function canAcceptString(string $codaLine)
 	{
 		return mb_strlen($codaLine) == 128 && mb_substr($codaLine, 0, 1) == "8";

--- a/src/LineParsers/TransactionPart2LineParser.php
+++ b/src/LineParsers/TransactionPart2LineParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\getTrimmedData;
-use function Codelicious\Coda\Helpers\trimSpace;
 use Codelicious\Coda\Lines\TransactionPart2Line;
 use Codelicious\Coda\Values\Bic;
 use Codelicious\Coda\Values\CategoryPurpose;
@@ -40,7 +38,7 @@ class TransactionPart2LineParser implements LineParserInterface
 			new Purpose(mb_substr($codaLine, 121, 4))
 		);
 	}
-	
+
 	public function canAcceptString(string $codaLine)
 	{
 		return mb_strlen($codaLine) == 128 && mb_substr($codaLine, 0, 2) == "22";

--- a/src/LineParsers/TransactionPart3LineParser.php
+++ b/src/LineParsers/TransactionPart3LineParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\LineParsers;
 
-use function Codelicious\Coda\Helpers\getTrimmedData;
-use function Codelicious\Coda\Helpers\trimSpace;
 use Codelicious\Coda\Lines\TransactionPart3Line;
 use Codelicious\Coda\Values\AccountFull;
 use Codelicious\Coda\Values\AccountName;
@@ -32,7 +30,7 @@ class TransactionPart3LineParser implements LineParserInterface
 			new Message(mb_substr($codaLine, 82, 43))
 		);
 	}
-	
+
 	public function canAcceptString(string $codaLine)
 	{
 		return mb_strlen($codaLine) == 128 && mb_substr($codaLine, 0, 2) == "23";

--- a/src/Lines/TransactionPart1Line.php
+++ b/src/Lines/TransactionPart1Line.php
@@ -6,17 +6,11 @@ use Codelicious\Coda\Values\Amount;
 use Codelicious\Coda\Values\BankReference;
 use Codelicious\Coda\Values\Date;
 use Codelicious\Coda\Values\GlobalizationCode;
-use Codelicious\Coda\Values\Message;
 use Codelicious\Coda\Values\MessageOrStructuredMessage;
-use Codelicious\Coda\Values\SepaDirectDebit;
 use Codelicious\Coda\Values\SequenceNumber;
 use Codelicious\Coda\Values\SequenceNumberDetail;
 use Codelicious\Coda\Values\StatementSequenceNumber;
 use Codelicious\Coda\Values\TransactionCode;
-use Codelicious\Coda\Values\TransactionCodeCategory;
-use Codelicious\Coda\Values\TransactionCodeFamily;
-use Codelicious\Coda\Values\TransactionCodeOperation;
-use Codelicious\Coda\Values\TransactionCodeType;
 
 /**
  * @package Codelicious\Coda
@@ -45,7 +39,7 @@ class TransactionPart1Line implements LineInterface
 	private $statementSequenceNumber;
 	/** @var GlobalizationCode */
 	private $globalizationCode;
-	
+
 	public function __construct(
 		SequenceNumber $sequenceNumber,
 		SequenceNumberDetail $sequenceNumberDetail,
@@ -69,57 +63,57 @@ class TransactionPart1Line implements LineInterface
 		$this->statementSequenceNumber = $statementSequenceNumber;
 		$this->globalizationCode = $globalizationCode;
 	}
-	
+
 	public function getType(): LineType
 	{
 		return new LineType(LineType::TransactionPart1);
 	}
-	
+
 	public function getSequenceNumber(): SequenceNumber
 	{
 		return $this->sequenceNumber;
 	}
-	
+
 	public function getSequenceNumberDetail(): SequenceNumberDetail
 	{
 		return $this->sequenceNumberDetail;
 	}
-	
+
 	public function getBankReference(): BankReference
 	{
 		return $this->bankReference;
 	}
-	
+
 	public function getAmount(): Amount
 	{
 		return $this->amount;
 	}
-	
+
 	public function getValutaDate(): Date
 	{
 		return $this->valutaDate;
 	}
-	
+
 	public function getTransactionCode(): TransactionCode
 	{
 		return $this->transactionCode;
 	}
-	
+
 	public function getMessageOrStructuredMessage(): MessageOrStructuredMessage
 	{
 		return $this->messageOrStructuredMessage;
 	}
-	
+
 	public function getTransactionDate(): Date
 	{
 		return $this->transactionDate;
 	}
-	
+
 	public function getStatementSequenceNumber(): StatementSequenceNumber
 	{
 		return $this->statementSequenceNumber;
 	}
-	
+
 	public function getGlobalizationCode(): GlobalizationCode
 	{
 		return $this->globalizationCode;

--- a/src/StatementParsers/TransactionParser.php
+++ b/src/StatementParsers/TransactionParser.php
@@ -35,14 +35,11 @@ class TransactionParser
 		$amount = 0.0;
 		$sepaDirectDebit = null;
 
-        /** @var string|null $transactionSequence */
-        $statementSequence = null;
+        /** @var int $transactionSequence */
+        $statementSequence = 0;
 
-		/** @var string|null $transactionSequence */
-        $transactionSequence = null;
-
-        /** @var string|null $transactionSequence */
-        $transactionSequenceDetail = null;
+		/** @var int $transactionSequence */
+        $transactionSequence = 0;
 
 		if ($transactionPart1Line) {
 			$valutaDate = $transactionPart1Line->getValutaDate()->getValue();
@@ -50,7 +47,6 @@ class TransactionParser
 			$amount = $transactionPart1Line->getAmount()->getValue();
             $statementSequence = $transactionPart1Line->getStatementSequenceNumber()->getValue();
             $transactionSequence = $transactionPart1Line->getSequenceNumber()->getValue();
-            $transactionSequenceDetail = $transactionPart1Line->getSequenceNumberDetail()->getValue();
 			if ($transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()) {
 				$sepaDirectDebit = $transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getSepaDirectDebit();
 			}
@@ -81,15 +77,14 @@ class TransactionParser
 
 		return new Transaction(
 			$account,
+            $statementSequence,
+            $transactionSequence,
 			$transactionDate,
 			$valutaDate,
 			$amount,
 			$message,
 			$structuredMessage,
-			$sepaDirectDebit,
-            $statementSequence,
-            $transactionSequence,
-            $transactionSequenceDetail
+			$sepaDirectDebit
 		);
 	}
 

--- a/src/StatementParsers/TransactionParser.php
+++ b/src/StatementParsers/TransactionParser.php
@@ -2,8 +2,6 @@
 
 namespace Codelicious\Coda\StatementParsers;
 
-use function Codelicious\Coda\Helpers\filterLinesOfTypes;
-use function Codelicious\Coda\Helpers\getFirstLineOfType;
 use Codelicious\Coda\Lines\InformationPart1Line;
 use Codelicious\Coda\Lines\LineInterface;
 use Codelicious\Coda\Lines\LineType;
@@ -12,6 +10,8 @@ use Codelicious\Coda\Lines\TransactionPart2Line;
 use Codelicious\Coda\Statements\Transaction;
 use Codelicious\Coda\Values\Message;
 use DateTime;
+use function Codelicious\Coda\Helpers\filterLinesOfTypes;
+use function Codelicious\Coda\Helpers\getFirstLineOfType;
 
 /**
  * @package Codelicious\Coda
@@ -35,19 +35,22 @@ class TransactionParser
 		$amount = 0.0;
 		$sepaDirectDebit = null;
 
+        /** @var string|null $transactionSequence */
+        $statementSequence = null;
+
 		/** @var string|null $transactionSequence */
         $transactionSequence = null;
 
         /** @var string|null $transactionSequence */
         $transactionSequenceDetail = null;
 
-        /** @var string|null $transactionSequence */
-        $statementSequence = null;
-
 		if ($transactionPart1Line) {
 			$valutaDate = $transactionPart1Line->getValutaDate()->getValue();
 			$transactionDate = $transactionPart1Line->getTransactionDate()->getValue();
 			$amount = $transactionPart1Line->getAmount()->getValue();
+            $statementSequence = $transactionPart1Line->getStatementSequenceNumber()->getValue();
+            $transactionSequence = $transactionPart1Line->getSequenceNumber()->getValue();
+            $transactionSequenceDetail = $transactionPart1Line->getSequenceNumberDetail()->getValue();
 			if ($transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()) {
 				$sepaDirectDebit = $transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getSepaDirectDebit();
 			}
@@ -57,9 +60,6 @@ class TransactionParser
 		$informationPart1Line = getFirstLineOfType($lines, new LineType(LineType::InformationPart1));
 
 		$structuredMessage = "";
-        $transactionSequence = $transactionPart1Line->getSequenceNumber()->getValue();
-        $transactionSequenceDetail = $transactionPart1Line->getSequenceNumberDetail()->getValue();
-        $statementSequence = $transactionPart1Line->getStatementSequenceNumber()->getValue();
 
 		if ($transactionPart1Line && $transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage() && !empty($transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getStructuredMessage())) {
 			$structuredMessage = $transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getStructuredMessage();

--- a/src/StatementParsers/TransactionParser.php
+++ b/src/StatementParsers/TransactionParser.php
@@ -20,10 +20,11 @@ use DateTime;
  */
 class TransactionParser
 {
-	/**
-	 * @param array $lines
-	 * @return Transaction
-	 */
+    /**
+     * @param array $lines
+     * @return Transaction
+     * @throws \Exception
+     */
 	public function parse(array $lines): Transaction
 	{
 		/** @var TransactionPart1Line $transactionPart1Line */
@@ -33,6 +34,16 @@ class TransactionParser
 		$valutaDate = new DateTime("0001-01-01");
 		$amount = 0.0;
 		$sepaDirectDebit = null;
+
+		/** @var string|null $transactionSequence */
+        $transactionSequence = null;
+
+        /** @var string|null $transactionSequence */
+        $transactionSequenceDetail = null;
+
+        /** @var string|null $transactionSequence */
+        $statementSequence = null;
+
 		if ($transactionPart1Line) {
 			$valutaDate = $transactionPart1Line->getValutaDate()->getValue();
 			$transactionDate = $transactionPart1Line->getTransactionDate()->getValue();
@@ -41,11 +52,15 @@ class TransactionParser
 				$sepaDirectDebit = $transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getSepaDirectDebit();
 			}
 		}
-		
+
 		/** @var InformationPart1Line $informationPart1Line */
 		$informationPart1Line = getFirstLineOfType($lines, new LineType(LineType::InformationPart1));
 
 		$structuredMessage = "";
+        $transactionSequence = $transactionPart1Line->getSequenceNumber()->getValue();
+        $transactionSequenceDetail = $transactionPart1Line->getSequenceNumberDetail()->getValue();
+        $statementSequence = $transactionPart1Line->getStatementSequenceNumber()->getValue();
+
 		if ($transactionPart1Line && $transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage() && !empty($transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getStructuredMessage())) {
 			$structuredMessage = $transactionPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getStructuredMessage();
 		} elseif ($informationPart1Line && $informationPart1Line->getMessageOrStructuredMessage()->getStructuredMessage() && !empty($informationPart1Line->getMessageOrStructuredMessage()->getStructuredMessage()->getStructuredMessage())) {
@@ -58,12 +73,12 @@ class TransactionParser
 				new LineType(LineType::TransactionPart2),
 				new LineType(LineType::TransactionPart3)
 			]);
-		
+
 		$accountOtherPartyParser = new AccountOtherPartyParser();
 		$account = $accountOtherPartyParser->parse($linesWithAccountInfo);
-		
+
 		$message = $this->constructMessage($lines);
-		
+
 		return new Transaction(
 			$account,
 			$transactionDate,
@@ -71,10 +86,13 @@ class TransactionParser
 			$amount,
 			$message,
 			$structuredMessage,
-			$sepaDirectDebit
+			$sepaDirectDebit,
+            $statementSequence,
+            $transactionSequence,
+            $transactionSequenceDetail
 		);
 	}
-	
+
 	/**
 	 * @param LineInterface[] $lines
 	 * @return string
@@ -88,7 +106,7 @@ class TransactionParser
 				new LineType(LineType::TransactionPart2),
 				new LineType(LineType::TransactionPart3)
 			]);
-		
+
 		$message = implode('', array_map(function($line) {
 				/** @var Message|null $message */
 				$message = null;
@@ -99,7 +117,7 @@ class TransactionParser
 				}
 				return $message?$message->getValue():"";
 			}, $transactionLines));
-		
+
 		if (!$message) {
 			/** @var TransactionPart2Line|null $transactionLine */
 			$transactionLine = getFirstLineOfType($lines, new LineType(LineType::TransactionPart2));
@@ -114,7 +132,7 @@ class TransactionParser
 					new LineType(LineType::InformationPart2),
 					new LineType(LineType::InformationPart3)
 				]);
-			
+
 			if ($message) {
 				$message .= " ";
 			}
@@ -129,7 +147,7 @@ class TransactionParser
 				return $message?$message->getValue():"";
 			}, $informationLines));
 		}
-		
+
 		return trim($message);
 	}
 }

--- a/src/Statements/Transaction.php
+++ b/src/Statements/Transaction.php
@@ -26,17 +26,37 @@ class Transaction
 	private $structuredMessage;
 	/** @var SepaDirectDebit|null */
 	private $sepaDirectDebit;
-	
-	/**
-	 * @param AccountOtherParty $account
-	 * @param DateTime $transactionDate
-	 * @param DateTime $valutaDate
-	 * @param float $amount
-	 * @param string $message
-	 * @param string $structuredMessage
-	 * @param SepaDirectDebit|null $sepaDirectDebit
-	 */
-	public function __construct(AccountOtherParty $account, DateTime $transactionDate, DateTime $valutaDate, float $amount, string $message, string $structuredMessage, $sepaDirectDebit)
+	/** @var string|null */
+    private $statementSequence;
+    /** @var string|null */
+    private $transactionSequence;
+    /** @var string|null */
+    private $transactionSequenceDetail;
+
+    /**
+     * @param AccountOtherParty $account
+     * @param DateTime $transactionDate
+     * @param DateTime $valutaDate
+     * @param float $amount
+     * @param string $message
+     * @param string $structuredMessage
+     * @param SepaDirectDebit|null $sepaDirectDebit
+     * @param $statementSequence
+     * @param $transactionSequence
+     * @param $transactionSequenceDetail
+     */
+	public function __construct(
+	    AccountOtherParty $account,
+        DateTime $transactionDate,
+        DateTime $valutaDate,
+        float $amount,
+        string $message,
+        string $structuredMessage,
+        $sepaDirectDebit,
+        $statementSequence,
+        $transactionSequence,
+        $transactionSequenceDetail
+    )
 	{
 		$this->account = $account;
 		$this->transactionDate = $transactionDate;
@@ -45,38 +65,41 @@ class Transaction
 		$this->message = $message;
 		$this->structuredMessage = $structuredMessage;
 		$this->sepaDirectDebit = $sepaDirectDebit;
-	}
-	
+        $this->statementSequence = $statementSequence;
+        $this->transactionSequence = $transactionSequence;
+        $this->transactionSequenceDetail = $transactionSequenceDetail;
+    }
+
 	public function getAccount(): AccountOtherParty
 	{
 		return $this->account;
 	}
-	
+
 	public function getTransactionDate(): DateTime
 	{
 		return $this->transactionDate;
 	}
-	
+
 	public function getValutaDate(): DateTime
 	{
 		return $this->valutaDate;
 	}
-	
+
 	public function getAmount(): float
 	{
 		return $this->amount;
 	}
-	
+
 	public function getMessage(): string
 	{
 		return $this->message;
 	}
-	
+
 	public function getStructuredMessage(): string
 	{
 		return $this->structuredMessage;
 	}
-	
+
 	/**
 	 * @return SepaDirectDebit|null
 	 */
@@ -84,6 +107,6 @@ class Transaction
 	{
 		return $this->sepaDirectDebit;
 	}
-	
-	
+
+
 }

--- a/src/Statements/Transaction.php
+++ b/src/Statements/Transaction.php
@@ -14,6 +14,10 @@ class Transaction
 {
     /** @var AccountOtherParty */
     private $account;
+    /** @var int */
+    private $statementSequence;
+    /** @var int */
+    private $transactionSequence;
     /** @var DateTime */
     private $transactionDate;
     /** @var DateTime */
@@ -26,48 +30,39 @@ class Transaction
     private $structuredMessage;
     /** @var SepaDirectDebit|null */
     private $sepaDirectDebit;
-    /** @var string|null */
-    private $statementSequence;
-    /** @var string|null */
-    private $transactionSequence;
-    /** @var string|null */
-    private $transactionSequenceDetail;
 
     /**
      * @param AccountOtherParty $account
+     * @param int $statementSequence
+     * @param int $transactionSequence
      * @param DateTime $transactionDate
      * @param DateTime $valutaDate
      * @param float $amount
      * @param string $message
      * @param string $structuredMessage
      * @param SepaDirectDebit|null $sepaDirectDebit
-     * @param string|null $statementSequence
-     * @param string|null $transactionSequence
-     * @param string|null $transactionSequenceDetail
      */
     public function __construct(
         AccountOtherParty $account,
+        int $statementSequence,
+        int $transactionSequence,
         DateTime $transactionDate,
         DateTime $valutaDate,
         float $amount,
         string $message,
         string $structuredMessage,
-        $sepaDirectDebit,
-        $statementSequence,
-        $transactionSequence,
-        $transactionSequenceDetail
+        $sepaDirectDebit
     )
     {
         $this->account = $account;
+        $this->statementSequence = $statementSequence;
+        $this->transactionSequence = $transactionSequence;
         $this->transactionDate = $transactionDate;
         $this->valutaDate = $valutaDate;
         $this->amount = $amount;
         $this->message = $message;
         $this->structuredMessage = $structuredMessage;
         $this->sepaDirectDebit = $sepaDirectDebit;
-        $this->statementSequence = $statementSequence;
-        $this->transactionSequence = $transactionSequence;
-        $this->transactionSequenceDetail = $transactionSequenceDetail;
     }
 
     public function getAccount(): AccountOtherParty
@@ -109,26 +104,18 @@ class Transaction
     }
 
     /**
-     * @return string|null
+     * @return int
      */
-    public function getStatementSequence()
+    public function getStatementSequence(): int
     {
         return $this->statementSequence;
     }
 
     /**
-     * @return string|null
+     * @return int
      */
-    public function getTransactionSequence()
+    public function getTransactionSequence(): int
     {
         return $this->transactionSequence;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getTransactionSequenceDetail()
-    {
-        return $this->transactionSequenceDetail;
     }
 }

--- a/src/Statements/Transaction.php
+++ b/src/Statements/Transaction.php
@@ -12,21 +12,21 @@ use DateTime;
  */
 class Transaction
 {
-	/** @var AccountOtherParty */
-	private $account;
-	/** @var DateTime */
-	private $transactionDate;
-	/** @var DateTime */
-	private $valutaDate;
-	/** @var float */
-	private $amount;
-	/** @var string */
-	private $message;
-	/** @var string */
-	private $structuredMessage;
-	/** @var SepaDirectDebit|null */
-	private $sepaDirectDebit;
-	/** @var string|null */
+    /** @var AccountOtherParty */
+    private $account;
+    /** @var DateTime */
+    private $transactionDate;
+    /** @var DateTime */
+    private $valutaDate;
+    /** @var float */
+    private $amount;
+    /** @var string */
+    private $message;
+    /** @var string */
+    private $structuredMessage;
+    /** @var SepaDirectDebit|null */
+    private $sepaDirectDebit;
+    /** @var string|null */
     private $statementSequence;
     /** @var string|null */
     private $transactionSequence;
@@ -41,12 +41,12 @@ class Transaction
      * @param string $message
      * @param string $structuredMessage
      * @param SepaDirectDebit|null $sepaDirectDebit
-     * @param $statementSequence
-     * @param $transactionSequence
-     * @param $transactionSequenceDetail
+     * @param string|null $statementSequence
+     * @param string|null $transactionSequence
+     * @param string|null $transactionSequenceDetail
      */
-	public function __construct(
-	    AccountOtherParty $account,
+    public function __construct(
+        AccountOtherParty $account,
         DateTime $transactionDate,
         DateTime $valutaDate,
         float $amount,
@@ -57,56 +57,78 @@ class Transaction
         $transactionSequence,
         $transactionSequenceDetail
     )
-	{
-		$this->account = $account;
-		$this->transactionDate = $transactionDate;
-		$this->valutaDate = $valutaDate;
-		$this->amount = $amount;
-		$this->message = $message;
-		$this->structuredMessage = $structuredMessage;
-		$this->sepaDirectDebit = $sepaDirectDebit;
+    {
+        $this->account = $account;
+        $this->transactionDate = $transactionDate;
+        $this->valutaDate = $valutaDate;
+        $this->amount = $amount;
+        $this->message = $message;
+        $this->structuredMessage = $structuredMessage;
+        $this->sepaDirectDebit = $sepaDirectDebit;
         $this->statementSequence = $statementSequence;
         $this->transactionSequence = $transactionSequence;
         $this->transactionSequenceDetail = $transactionSequenceDetail;
     }
 
-	public function getAccount(): AccountOtherParty
-	{
-		return $this->account;
-	}
+    public function getAccount(): AccountOtherParty
+    {
+        return $this->account;
+    }
 
-	public function getTransactionDate(): DateTime
-	{
-		return $this->transactionDate;
-	}
+    public function getTransactionDate(): DateTime
+    {
+        return $this->transactionDate;
+    }
 
-	public function getValutaDate(): DateTime
-	{
-		return $this->valutaDate;
-	}
+    public function getValutaDate(): DateTime
+    {
+        return $this->valutaDate;
+    }
 
-	public function getAmount(): float
-	{
-		return $this->amount;
-	}
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
 
-	public function getMessage(): string
-	{
-		return $this->message;
-	}
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
 
-	public function getStructuredMessage(): string
-	{
-		return $this->structuredMessage;
-	}
+    public function getStructuredMessage(): string
+    {
+        return $this->structuredMessage;
+    }
 
-	/**
-	 * @return SepaDirectDebit|null
-	 */
-	public function getSepaDirectDebit()
-	{
-		return $this->sepaDirectDebit;
-	}
+    /**
+     * @return SepaDirectDebit|null
+     */
+    public function getSepaDirectDebit()
+    {
+        return $this->sepaDirectDebit;
+    }
 
+    /**
+     * @return string|null
+     */
+    public function getStatementSequence()
+    {
+        return $this->statementSequence;
+    }
 
+    /**
+     * @return string|null
+     */
+    public function getTransactionSequence()
+    {
+        return $this->transactionSequence;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTransactionSequenceDetail()
+    {
+        return $this->transactionSequenceDetail;
+    }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -35,25 +35,22 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($transaction1->getTransactionDate());
         $this->assertNotEmpty($transaction1->getValutaDate());
         $this->assertNotEmpty($transaction1->getMessage());
-        $this->assertEquals("1", $transaction1->getTransactionSequence());
-        $this->assertEquals("0", $transaction1->getTransactionSequenceDetail());
-        $this->assertEquals("214", $transaction1->getStatementSequence());
+        $this->assertEquals(1, $transaction1->getTransactionSequence());
+        $this->assertEquals(214, $transaction1->getStatementSequence());
 
         $this->assertNotEmpty($transaction2->getAccount());
         $this->assertNotEmpty($transaction2->getTransactionDate());
         $this->assertNotEmpty($transaction2->getValutaDate());
         $this->assertNotEmpty($transaction2->getStructuredMessage());
-        $this->assertEquals("2", $transaction2->getTransactionSequence());
-        $this->assertEquals("0", $transaction2->getTransactionSequenceDetail());
-        $this->assertEquals("214", $transaction2->getStatementSequence());
+        $this->assertEquals(2, $transaction2->getTransactionSequence());
+        $this->assertEquals(214, $transaction2->getStatementSequence());
 
         $this->assertNotEmpty($transaction3->getAccount());
         $this->assertNotEmpty($transaction3->getTransactionDate());
         $this->assertNotEmpty($transaction3->getValutaDate());
         $this->assertNotEmpty($transaction3->getMessage());
-        $this->assertEquals("9", $transaction3->getTransactionSequence());
-        $this->assertEquals("0", $transaction3->getTransactionSequenceDetail());
-        $this->assertEquals("214", $transaction3->getStatementSequence());
+        $this->assertEquals(9, $transaction3->getTransactionSequence());
+        $this->assertEquals(214, $transaction3->getStatementSequence());
     }
 
     public function testMessageOnMultipleLinesTransactionBlock()
@@ -143,21 +140,18 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("GEBCEEBB", $transaction1->getAccount()->getBic());
         $this->assertEquals("BE54805480215856", $transaction1->getAccount()->getNumber());
         $this->assertEquals("EUR", $transaction1->getAccount()->getCurrencyCode());
-        $this->assertEquals("1", $transaction1->getTransactionSequence());
-        $this->assertEquals("0", $transaction1->getTransactionSequenceDetail());
-        $this->assertEquals("214", $transaction1->getStatementSequence());
+        $this->assertEquals(1, $transaction1->getTransactionSequence());
+        $this->assertEquals(214, $transaction1->getStatementSequence());
 
         $this->assertEquals("54875", $transaction2->getMessage());
         $this->assertEquals("112455446812", $transaction2->getStructuredMessage());
-        $this->assertEquals("2", $transaction2->getTransactionSequence());
-        $this->assertEquals("0", $transaction2->getTransactionSequenceDetail());
-        $this->assertEquals("214", $transaction2->getStatementSequence());
+        $this->assertEquals(2, $transaction2->getTransactionSequence());
+        $this->assertEquals(214, $transaction2->getStatementSequence());
 
         $this->assertEmpty($transaction3->getAccount()->getName());
         $this->assertEquals("GEBCEEBB", $transaction3->getAccount()->getBic());
-        $this->assertEquals("9", $transaction3->getTransactionSequence());
-        $this->assertEquals("0", $transaction1->getTransactionSequenceDetail());
-        $this->assertEquals("214", $transaction3->getStatementSequence());
+        $this->assertEquals(9, $transaction3->getTransactionSequence());
+        $this->assertEquals(214, $transaction3->getStatementSequence());
     }
 
     private function getSamplePath($sampleFile)

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -35,116 +35,133 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($transaction1->getTransactionDate());
         $this->assertNotEmpty($transaction1->getValutaDate());
         $this->assertNotEmpty($transaction1->getMessage());
+        $this->assertEquals("1", $transaction1->getTransactionSequence());
+        $this->assertEquals("0", $transaction1->getTransactionSequenceDetail());
+        $this->assertEquals("214", $transaction1->getStatementSequence());
 
         $this->assertNotEmpty($transaction2->getAccount());
         $this->assertNotEmpty($transaction2->getTransactionDate());
         $this->assertNotEmpty($transaction2->getValutaDate());
         $this->assertNotEmpty($transaction2->getStructuredMessage());
+        $this->assertEquals("2", $transaction2->getTransactionSequence());
+        $this->assertEquals("0", $transaction2->getTransactionSequenceDetail());
+        $this->assertEquals("214", $transaction2->getStatementSequence());
 
         $this->assertNotEmpty($transaction3->getAccount());
         $this->assertNotEmpty($transaction3->getTransactionDate());
         $this->assertNotEmpty($transaction3->getValutaDate());
         $this->assertNotEmpty($transaction3->getMessage());
+        $this->assertEquals("9", $transaction3->getTransactionSequence());
+        $this->assertEquals("0", $transaction3->getTransactionSequenceDetail());
+        $this->assertEquals("214", $transaction3->getStatementSequence());
     }
 
-	public function testMessageOnMultipleLinesTransactionBlock()
-	{
-		$parser = new Parser();
-		/** @var Statement[] $result */
-		$result = $parser->parseFile($this->getSamplePath('sample3.cod'));
-		
-		$this->assertEquals("Message goes here and continues here or here", $result[0]->getTransactions()[0]->getMessage());
-	}
-	
-	public function testMessageOnMultipleLinesInformationBlock()
-	{
-		$parser = new Parser();
-		/** @var Statement[] $result */
-		$result = $parser->parseFile($this->getSamplePath('sample4.cod'));
-		
-		$this->assertEquals("Europese overschrijving (zie bijlage)  + 17.233,54Van: COMPANY BLABLABLAH BVBA - BE64NOT PR", $result[0]->getTransactions()[0]->getMessage());
-	}
-	
-	public function testNoAccount()
-	{
-		$parser = new Parser();
-		/** @var Statement[] $result */
-		$result = $parser->parseFile($this->getSamplePath('sample2.cod'));
-		
-		$this->assertEmpty($result[0]->getTransactions()[0]->getAccount()->getName());
-		$this->assertEquals("Zichtrekening nr  21354598  - 2,11Justification in annex 00001680", $result[0]->getTransactions()[0]->getMessage());
-	}
-	
-	public function testHas4EntriesWithStructuredMessage()
-	{
-		$parser = new Parser();
-		/** @var Statement[] $result */
-		$result = $parser->parseFile($this->getSamplePath('sample1.cod'));
-		
-		$this->assertCount(1, $result);
-		$this->assertEquals(17752.12, $result[0]->getInitialBalance());
-		$this->assertEquals(17832.12, $result[0]->getNewBalance());
-		$this->assertEquals(new DateTime("2017-10-11"), $result[0]->getDate());
-		$this->assertEmpty($result[0]->getInformationalMessage());
-		
-		$this->assertCount(4, $result[0]->getTransactions());
-		$this->assertEquals("GROTE WEG            32            3215    HASSELT", $result[0]->getTransactions()[0]->getMessage());
-		$this->assertEquals("000003505158", $result[0]->getTransactions()[0]->getStructuredMessage());
-		$this->assertEquals(5, $result[0]->getTransactions()[0]->getAmount());
-		$this->assertEquals("KLANT1 MET NAAM1", $result[0]->getTransactions()[0]->getAccount()->getName());
-		$this->assertEquals("BE22313215646432", $result[0]->getTransactions()[0]->getAccount()->getNumber());
-	}
-	
-	public function testSample6()
-	{
-		$parser = new Parser();
-		
-		/** @var Statement[] $result */
-		$result = $parser->parseFile($this->getSamplePath('sample6.cod'));
-		
-		$this->assertCount(1, $result);
-		$statement = $result[0];
-		
-		$this->assertNotEmpty($statement->getAccount());
-		$this->assertEquals(3, count($statement->getTransactions()));
-		$this->assertEquals(new DateTime("2015-01-18"), $statement->getDate());
-		$this->assertEquals(4004.1, $statement->getInitialBalance());
-		$this->assertEquals(-500012.1, $statement->getNewBalance());
-		$this->assertEquals("THIS IS A PUBLIC MESSAGE", $statement->getInformationalMessage());
-		
-		$this->assertEquals("CODELICIOUS", $statement->getAccount()->getName());
-		$this->assertEquals("GEBABEBB", $statement->getAccount()->getBic());
-		$this->assertEquals("09029308273", $statement->getAccount()->getCompanyIdentificationNumber());
-		$this->assertEquals("001548226815", $statement->getAccount()->getNumber());
-		$this->assertEquals("EUR", $statement->getAccount()->getCurrencyCode());
-		$this->assertEquals("BE", $statement->getAccount()->getCountryCode());
-		
-		$transaction1 = $statement->getTransactions()[0];
-		$transaction2 = $statement->getTransactions()[1];
-		$transaction3 = $statement->getTransactions()[2];
-		
-		$this->assertNotEmpty($transaction1->getAccount());
-		$this->assertEquals(new DateTime("2014-12-25"), $transaction1->getTransactionDate());
-		$this->assertEquals(new DateTime("2014-12-25"), $transaction1->getValutaDate());
-		$this->assertEquals(-767.823, $transaction1->getAmount());
-		$this->assertEquals("112/4554/46812   813  ANOTHER MESSAGE  MESSAGE", $transaction1->getMessage());
-		$this->assertEmpty($transaction1->getStructuredMessage());
-		
-		$this->assertEquals("BVBA.BAKKER PIET", $transaction1->getAccount()->getName());
-		$this->assertEquals("GEBCEEBB", $transaction1->getAccount()->getBic());
-		$this->assertEquals("BE54805480215856", $transaction1->getAccount()->getNumber());
-		$this->assertEquals("EUR", $transaction1->getAccount()->getCurrencyCode());
-		
-		$this->assertEquals("54875", $transaction2->getMessage());
-		$this->assertEquals("112455446812", $transaction2->getStructuredMessage());
-		
-		$this->assertEmpty($transaction3->getAccount()->getName());
-		$this->assertEquals("GEBCEEBB", $transaction3->getAccount()->getBic());
-	}
-	
-	private function getSamplePath($sampleFile)
-	{
-		return __DIR__ . DIRECTORY_SEPARATOR .'Samples' . DIRECTORY_SEPARATOR . $sampleFile;
-	}
+    public function testMessageOnMultipleLinesTransactionBlock()
+    {
+        $parser = new Parser();
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample3.cod'));
 
+        $this->assertEquals("Message goes here and continues here or here", $result[0]->getTransactions()[0]->getMessage());
+    }
+
+    public function testMessageOnMultipleLinesInformationBlock()
+    {
+        $parser = new Parser();
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample4.cod'));
+
+        $this->assertEquals("Europese overschrijving (zie bijlage)  + 17.233,54Van: COMPANY BLABLABLAH BVBA - BE64NOT PR", $result[0]->getTransactions()[0]->getMessage());
+    }
+
+    public function testNoAccount()
+    {
+        $parser = new Parser();
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample2.cod'));
+
+        $this->assertEmpty($result[0]->getTransactions()[0]->getAccount()->getName());
+        $this->assertEquals("Zichtrekening nr  21354598  - 2,11Justification in annex 00001680", $result[0]->getTransactions()[0]->getMessage());
+    }
+
+    public function testHas4EntriesWithStructuredMessage()
+    {
+        $parser = new Parser();
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample1.cod'));
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(17752.12, $result[0]->getInitialBalance());
+        $this->assertEquals(17832.12, $result[0]->getNewBalance());
+        $this->assertEquals(new DateTime("2017-10-11"), $result[0]->getDate());
+        $this->assertEmpty($result[0]->getInformationalMessage());
+
+        $this->assertCount(4, $result[0]->getTransactions());
+        $this->assertEquals("GROTE WEG            32            3215    HASSELT", $result[0]->getTransactions()[0]->getMessage());
+        $this->assertEquals("000003505158", $result[0]->getTransactions()[0]->getStructuredMessage());
+        $this->assertEquals(5, $result[0]->getTransactions()[0]->getAmount());
+        $this->assertEquals("KLANT1 MET NAAM1", $result[0]->getTransactions()[0]->getAccount()->getName());
+        $this->assertEquals("BE22313215646432", $result[0]->getTransactions()[0]->getAccount()->getNumber());
+    }
+
+    public function testSample6()
+    {
+        $parser = new Parser();
+
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample6.cod'));
+
+        $this->assertCount(1, $result);
+        $statement = $result[0];
+
+        $this->assertNotEmpty($statement->getAccount());
+        $this->assertEquals(3, count($statement->getTransactions()));
+        $this->assertEquals(new DateTime("2015-01-18"), $statement->getDate());
+        $this->assertEquals(4004.1, $statement->getInitialBalance());
+        $this->assertEquals(-500012.1, $statement->getNewBalance());
+        $this->assertEquals("THIS IS A PUBLIC MESSAGE", $statement->getInformationalMessage());
+
+        $this->assertEquals("CODELICIOUS", $statement->getAccount()->getName());
+        $this->assertEquals("GEBABEBB", $statement->getAccount()->getBic());
+        $this->assertEquals("09029308273", $statement->getAccount()->getCompanyIdentificationNumber());
+        $this->assertEquals("001548226815", $statement->getAccount()->getNumber());
+        $this->assertEquals("EUR", $statement->getAccount()->getCurrencyCode());
+        $this->assertEquals("BE", $statement->getAccount()->getCountryCode());
+
+        $transaction1 = $statement->getTransactions()[0];
+        $transaction2 = $statement->getTransactions()[1];
+        $transaction3 = $statement->getTransactions()[2];
+
+        $this->assertNotEmpty($transaction1->getAccount());
+        $this->assertEquals(new DateTime("2014-12-25"), $transaction1->getTransactionDate());
+        $this->assertEquals(new DateTime("2014-12-25"), $transaction1->getValutaDate());
+        $this->assertEquals(-767.823, $transaction1->getAmount());
+        $this->assertEquals("112/4554/46812   813  ANOTHER MESSAGE  MESSAGE", $transaction1->getMessage());
+        $this->assertEmpty($transaction1->getStructuredMessage());
+
+        $this->assertEquals("BVBA.BAKKER PIET", $transaction1->getAccount()->getName());
+        $this->assertEquals("GEBCEEBB", $transaction1->getAccount()->getBic());
+        $this->assertEquals("BE54805480215856", $transaction1->getAccount()->getNumber());
+        $this->assertEquals("EUR", $transaction1->getAccount()->getCurrencyCode());
+        $this->assertEquals("1", $transaction1->getTransactionSequence());
+        $this->assertEquals("0", $transaction1->getTransactionSequenceDetail());
+        $this->assertEquals("214", $transaction1->getStatementSequence());
+
+        $this->assertEquals("54875", $transaction2->getMessage());
+        $this->assertEquals("112455446812", $transaction2->getStructuredMessage());
+        $this->assertEquals("2", $transaction2->getTransactionSequence());
+        $this->assertEquals("0", $transaction2->getTransactionSequenceDetail());
+        $this->assertEquals("214", $transaction2->getStatementSequence());
+
+        $this->assertEmpty($transaction3->getAccount()->getName());
+        $this->assertEquals("GEBCEEBB", $transaction3->getAccount()->getBic());
+        $this->assertEquals("9", $transaction3->getTransactionSequence());
+        $this->assertEquals("0", $transaction1->getTransactionSequenceDetail());
+        $this->assertEquals("214", $transaction3->getStatementSequence());
+    }
+
+    private function getSamplePath($sampleFile)
+    {
+        return __DIR__ . DIRECTORY_SEPARATOR . 'Samples' . DIRECTORY_SEPARATOR . $sampleFile;
+    }
 }


### PR DESCRIPTION
To be able to detect duplicate database entries, I need to check if a coda/transaction was already inserted (based on its sequence number). Since the sequence numbers were read/parsed, but not exposed to the transaction, I added these.