### PR TITLE
Add client reference to transaction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,15 @@
 	"authors": [
 		{ "name": "Wim Verstuyf", "email": "wim.verstuyf@codelicious.be" }
 	],
-	"require": {	
+	"require": {
 		"php": ">=7.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "9.*"
-	},	
+	},
+	"scripts": {
+		"test": "phpunit"
+	},
 	"autoload": {
 		"psr-4":{
 			"Codelicious\\Coda\\": ["src/"]

--- a/src/StatementParsers/TransactionParser.php
+++ b/src/StatementParsers/TransactionParser.php
@@ -99,6 +99,12 @@ class TransactionParser
 
 		$message = $this->constructMessage($lines);
 
+		$transactionPart2Line = getFirstLineOfType($lines, new LineType(LineType::TransactionPart2));
+		$clientReference = '';
+		if ($transactionPart2Line !== null && !empty($transactionPart2Line->getClientReference()->getValue())) {
+			$clientReference = $transactionPart2Line->getClientReference()->getValue();
+		}
+
 		return new Transaction(
 			$account,
 			$statementSequence,
@@ -110,7 +116,8 @@ class TransactionParser
 			$message,
 			$structuredMessage,
 			$sepaDirectDebit,
-			$transactionCode
+			$transactionCode,
+			$clientReference
 		);
 	}
 

--- a/src/Statements/Transaction.php
+++ b/src/Statements/Transaction.php
@@ -33,7 +33,9 @@ class Transaction
     /** @var SepaDirectDebit|null */
     private $sepaDirectDebit;
     /** @var TransactionCode|null */
-   	private $transactionCode;
+    private $transactionCode;
+    /** @var string */
+    private $clientReference;
 
     /**
      * @param AccountOtherParty $account
@@ -45,6 +47,7 @@ class Transaction
      * @param string $message
      * @param string $structuredMessage
      * @param SepaDirectDebit|null $sepaDirectDebit
+     * @param string $clientReference
      */
     public function __construct(
         AccountOtherParty $account,
@@ -57,7 +60,8 @@ class Transaction
         string $message,
         string $structuredMessage,
         $sepaDirectDebit,
-        TransactionCode $transactionCode
+        TransactionCode $transactionCode,
+        string $clientReference
     )
     {
         $this->account = $account;
@@ -71,6 +75,7 @@ class Transaction
         $this->structuredMessage = $structuredMessage;
         $this->sepaDirectDebit = $sepaDirectDebit;
         $this->transactionCode = $transactionCode;
+        $this->clientReference = $clientReference;
     }
 
     public function getAccount(): AccountOtherParty
@@ -141,5 +146,13 @@ class Transaction
     public function getTransactionCode(): TransactionCode
     {
         return $this->transactionCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientReference(): string
+    {
+        return $this->clientReference;
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -196,6 +196,18 @@ class ParserTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(2, $result[0]->getTransactions());
     }
 
+    public function testClientReference()
+    {
+        $parser = new Parser();
+
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample9.cod'));
+
+        $this->assertCount(1, $result);
+        $this->assertCount(1, $result[0]->getTransactions());
+        $this->assertSame('243690000141', $result[0]->getTransactions()[0]->getClientReference());
+    }
+
     private function getSamplePath($sampleFile)
     {
         return __DIR__ . DIRECTORY_SEPARATOR . 'Samples' . DIRECTORY_SEPARATOR . $sampleFile;

--- a/tests/Samples/sample9.cod
+++ b/tests/Samples/sample9.cod
@@ -1,0 +1,9 @@
+0000011101772505        00265207  BOUWBEDRIJF VOOR GROTE WERKREDBEBB   00330158420 00000                                       2
+10139138536152215 EUR0BE                  0000000017752120101017BOUWBEDRIJF VOOR GROTE WERKBC-Bedrijfsrekening               138
+2100010000JRFC00120DSCCOCACAERT0000000000005000111017001500001101000003505158                                      11101713901 0
+2200010000                                                     243690000141                       KREDBEBB                   1 0
+2300010000BE22313215646432                     KLANT1 MET NAAM1                                                              0 1
+3100010001JRFC00120DSCCOCACAERT001500001001KLANT1 MET NAAM1                                                                  1 0
+3200010001GROTE WEG            32            3215    HASSELT                                                                 0 0
+8139138536152215 EUR0BE                  0000000017832120111017                                                                0
+9               000022000000000000000000000000080000                                                                           1


### PR DESCRIPTION
Could it be possible to add the original client reference to the transaction?

The reason I'm asking is because we store our own PO number in the client reference which makes it easier to link the coda transaction to an incoming invoice. This makes balancing our accounts/ledgers in our accounting software a lot easier.