### PR TITLE
Fix for Issue #29: Extract details for totalized transactions when available

### DIFF
--- a/src/StatementParsers/StatementParser.php
+++ b/src/StatementParsers/StatementParser.php
@@ -126,11 +126,13 @@ class StatementParser
 			/** @var TransactionPart1Line|TransactionPart2Line|TransactionPart3Line|InformationPart1Line|InformationPart2Line|InformationPart3Line $transactionOrInformationLine */
 			$transactionOrInformationLine = $line;
 			$isCollectiveTransaction = method_exists($transactionOrInformationLine, 'getTransactionCode') && $transactionOrInformationLine->getTransactionCode()->getOperation()->getValue() === '07';
+			$isTotalizedDetail = $transactionOrInformationLine->getType()->getValue() === LineType::TransactionPart1 && $transactionOrInformationLine->getTransactionCode()->getType()->getValue() === '5';
 
 			if (
 				!$transactions
 				|| $sequenceNumber != $transactionOrInformationLine->getSequenceNumber()->getValue()
 				|| ($isCollectiveTransaction && $sequenceNumberDetail != $transactionOrInformationLine->getSequenceNumberDetail()->getValue())
+				|| ($isTotalizedDetail && $sequenceNumberDetail != $transactionOrInformationLine->getSequenceNumberDetail()->getValue())
 			) {
 				$sequenceNumber = $transactionOrInformationLine->getSequenceNumber()->getValue();
 				$sequenceNumberDetail = $transactionOrInformationLine->getSequenceNumberDetail()->getValue();

--- a/src/StatementParsers/TransactionParser.php
+++ b/src/StatementParsers/TransactionParser.php
@@ -138,8 +138,8 @@ class TransactionParser
 				continue;
 			}
 
-			if ($transactionPart1Line && 
-				$transactionPart1Line->getTransactionCode()->getOperation()->getValue() === '07' && 
+			if ($transactionPart1Line &&
+				($transactionPart1Line->getTransactionCode()->getOperation()->getValue() === '07' || $transactionPart1Line->getTransactionCode()->getType()->getValue() === '1') &&
 				$transactionPart1Line->getGlobalizationCode()->getValue() > 0) {
 
 				$nextTransactionPart1Line = null;
@@ -150,8 +150,8 @@ class TransactionParser
 					}
 				}
 
-				if ($nextTransactionPart1Line && 
-					$nextTransactionPart1Line->getTransactionCode()->getOperation()->getValue() === '07' && 
+				if ($nextTransactionPart1Line &&
+					($nextTransactionPart1Line->getTransactionCode()->getOperation()->getValue() === '07' || $nextTransactionPart1Line->getTransactionCode()->getType()->getValue() === '5') &&
 					$nextTransactionPart1Line->getGlobalizationCode()->getValue() < $transactionPart1Line->getGlobalizationCode()->getValue()) {
 
 					continue;

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -208,6 +208,48 @@ class ParserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('243690000141', $result[0]->getTransactions()[0]->getClientReference());
     }
 
+    public function testTotaledTransactionsWithDetails()
+    {
+        $parser = new Parser();
+
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample10.cod'));
+
+        $this->assertCount(1, $result);
+
+        $this->assertEquals(100, $result[0]->getInitialBalance());
+        $this->assertEquals(1100, $result[0]->getNewBalance());
+        $this->assertEquals(new DateTime('2024-06-06'), $result[0]->getDate());
+        $this->assertEmpty($result[0]->getInformationalMessage());
+
+        $this->assertCount(2, $result[0]->getTransactions());
+        $this->assertEquals(250, $result[0]->getTransactions()[0]->getAmount());
+        $this->assertEquals('KLANT1 MET NAAM1', $result[0]->getTransactions()[0]->getAccount()->getName());
+        $this->assertEquals('BE22313215646432', $result[0]->getTransactions()[0]->getAccount()->getNumber());
+
+        $this->assertEquals(750, $result[0]->getTransactions()[1]->getAmount());
+        $this->assertEquals('KLANT2 MET NAAM2', $result[0]->getTransactions()[1]->getAccount()->getName());
+        $this->assertEquals('BE25646548413215', $result[0]->getTransactions()[1]->getAccount()->getNumber());
+    }
+
+    public function testTotaledTransactionsNoDetails()
+    {
+        $parser = new Parser();
+
+        /** @var Statement[] $result */
+        $result = $parser->parseFile($this->getSamplePath('sample11.cod'));
+
+        $this->assertCount(1, $result);
+
+        $this->assertEquals(100, $result[0]->getInitialBalance());
+        $this->assertEquals(1100, $result[0]->getNewBalance());
+        $this->assertEquals(new DateTime('2024-06-06'), $result[0]->getDate());
+        $this->assertEmpty($result[0]->getInformationalMessage());
+
+        $this->assertCount(1, $result[0]->getTransactions());
+        $this->assertEquals(1000, $result[0]->getTransactions()[0]->getAmount());
+    }
+
     private function getSamplePath($sampleFile)
     {
         return __DIR__ . DIRECTORY_SEPARATOR . 'Samples' . DIRECTORY_SEPARATOR . $sampleFile;

--- a/tests/Samples/sample10.cod
+++ b/tests/Samples/sample10.cod
@@ -1,0 +1,16 @@
+0000006062472505        00265207  BOUWBEDRIJF VOOR GROTE WERKREDBEBB   00330158420 00000                                       2
+10158138536152215 EUR0BE                  0000000000100000050624BOUWBEDRIJF VOOR GROTE WERKBC-Bedrijfsrekening               158
+2100010000BANK-REF-AAAAAAAAAAAA0000000001000000060624105500000                                                     06062415811 0
+2200010000                                                     REF-RECUR-06-05                                               0 0
+2100010001BANK-REF-BBBBBBBBBBBB0000000000250000060624505500001127060624120BBE2ZZZ3215646432                  SEPA-006062415801 0
+220001000100000001                     243690000141            243690000141                       KREDBEBB           SUPP    1 0
+2300010001BE22313215646432                     KLANT1 MET NAAM1                                                         0    0 1
+3100010002BANK-REF-BBBBBBBBBBBB505500001001KLANT1 MET NAAM1                                                                  1 0
+3200010002GROTE WEG            32            3215    HASSELT                                                                 0 0
+2100010003BANK-REF-CCCCCCCCCCCC0000000000750000060624505500001127060624120BE25ZZZ548413215                   SEPA-006062415801 0
+22000100030000002                      243690000142            243690000142                       KREDBEBB           SUPP    1 0
+2300010003BE25646548413215                     KLANT2 MET NAAM2                                                         0    0 1
+3100010004BANK-REF-CCCCCCCCCCCC505500001001KLANT2 MET NAAM2                                                                  1 0
+3200010004OETGANGERSTRAAT 26                1215        ANTWERPEN                                                            0 0
+8158138536152215 EUR0BE                  0000000001100000060624                                                                0
+9               000014000000000000000000000001000000                                                                           2

--- a/tests/Samples/sample11.cod
+++ b/tests/Samples/sample11.cod
@@ -1,0 +1,6 @@
+0000006062472505        00265207  BOUWBEDRIJF VOOR GROTE WERKREDBEBB   00330158420 00000                                       2
+10158138536152215 EUR0BE                  0000000000100000050624BOUWBEDRIJF VOOR GROTE WERKBC-Bedrijfsrekening               158
+2100010000BANK-REF-AAAAAAAAAAAA0000000001000000060624105500000                                                     06062415811 0
+2200010000                                                     REF-RECUR-06-05                                               0 0
+8158138536152215 EUR0BE                  0000000001100000060624                                                                0
+9               000004000000000000000000000001000000                                                                           2


### PR DESCRIPTION
**Summary**

This pull request addresses the issue reported in https://github.com/wimverstuyf/php-coda-parser/issues/29. 
The problem concerns to the incorrect parsing of grouped transactions with detailed transaction lines (e.g. SEPA transactions).

**Problem**
Grouped transactions with a totalized amount (Transaction code in record 21 starting with "1") followed by detailed transactions (Transaction code in record 21 starting with "5") are not parsed correctly. The parser treats the entire group and its detailed transactions as a single transaction, leading to the following issues:

* Loss of individual transaction details.
* Incorrectly concatenated transaction information.
* Erroneous (structured-)message information due to concatenation of multiple transactions.

**Solution**
The changes in this pull request modify the parsing logic to:

* Identify and ignore the globalized transaction if it is followed by its detailed transactions.
* Ensure each detailed transaction is parsed and recorded individually, preserving the integrity of transaction information.
* The totalized transaction is still provided in the list of transactions, but only if no detailed transactions are provided.

**Impact**
These changes ensure that grouped transactions are no longer incorrectly concatenated, and each detailed transaction retains its individual details, improving the accuracy of parsed transaction data.

Feel free to reach out if there are any questions or further clarifications needed.

Thank you for reviewing this pull request.